### PR TITLE
METRON-944 fix numbered lists

### DIFF
--- a/metron-interface/metron-rest/README.md
+++ b/metron-interface/metron-rest/README.md
@@ -14,19 +14,19 @@ This module provides a RESTful API for interacting with Metron.
 ### From Source
 
 1. Package the application with Maven:
-```
+  ```
 mvn clean package
-```
+  ```
 
 1. Untar the archive in the $METRON_HOME directory.  The directory structure will look like:
-```
+  ```
 config
   rest_application.yml
 bin
   metron-rest
 lib
   metron-rest-$METRON_VERSION.jar
-```
+  ```
 
 1. Copy the `$METRON_HOME/bin/metron-rest` script to `/etc/init.d/metron-rest`
 
@@ -35,9 +35,9 @@ lib
 1. Deploy the RPM at `/incubator-metron/metron-deployment/packaging/docker/rpm-docker/target/RPMS/noarch/metron-rest-$METRON_VERSION-*.noarch.rpm`
 
 1. Install the RPM with:
-   ```
-   rpm -ih metron-rest-$METRON_VERSION-*.noarch.rpm
-   ```
+  ```
+rpm -ih metron-rest-$METRON_VERSION-*.noarch.rpm
+  ```
 
 ## Configuration
 
@@ -105,27 +105,27 @@ For example, the following configures the application for MySQL:
 1. Install MySQL if not already available (this example uses version 5.7, installation instructions can be found [here](https://dev.mysql.com/doc/refman/5.7/en/linux-installation-yum-repo.html))
 
 1. Create a metron user and REST database and permission the user for that database:
-```
+  ```
 CREATE USER 'metron'@'node1' IDENTIFIED BY 'Myp@ssw0rd';
 CREATE DATABASE IF NOT EXISTS metronrest;
 GRANT ALL PRIVILEGES ON metronrest.* TO 'metron'@'node1';
-```
+  ```
 
 1. Install the MySQL JDBC client onto the REST application host and configurate the METRON_JDBC_CLIENT_PATH variable:
-```
+  ```
 cd $METRON_HOME/lib
 wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.41.tar.gz
 tar xf mysql-connector-java-5.1.41.tar.gz
-```
+  ```
 
 1. Edit these variables in `/etc/sysconfig/metron` to configure the REST application for MySQL:
-```
+  ```
 METRON_JDBC_DRIVER="com.mysql.jdbc.Driver"
 METRON_JDBC_URL="jdbc:mysql://mysql_host:3306/metronrest"
 METRON_JDBC_USERNAME="metron"
 METRON_JDBC_PLATFORM="mysql"
 METRON_JDBC_CLIENT_PATH=$METRON_HOME/lib/mysql-connector-java-5.1.41/mysql-connector-java-5.1.41-bin.jar
-```
+  ```
 
 ## Usage
 
@@ -610,6 +610,7 @@ Start the [metron-docker](../../metron-docker) environment.  Build the metron-re
 mvn clean package
 mvn spring-boot:run -Drun.profiles=docker,dev
 ```
+
 The metron-rest application will be available at http://localhost:8080/swagger-ui.html#/.
 
 ### Quick Dev
@@ -619,12 +620,14 @@ Start the [Quick Dev](../../metron-deployment/vagrant/quick-dev-platform) enviro
 mvn clean package
 mvn spring-boot:run -Drun.profiles=vagrant,dev
 ```
+
 The metron-rest application will be available at http://localhost:8080/swagger-ui.html#/.
 
 To run the application locally on the Quick Dev host (node1), follow the [Installation](#installation) instructions above.  Then set the METRON_SPRING_PROFILES_ACTIVE variable in `/etc/sysconfig/metron`:
 ```
 METRON_SPRING_PROFILES_ACTIVE="vagrant,dev"
 ```
+
 and start the application:
 ```
 service metron-rest start
@@ -636,6 +639,7 @@ METRON_SPRING_PROFILES_ACTIVE="vagrant,dev"
 METRON_JVMFLAGS="-Djava.security.auth.login.config=$METRON_HOME/client_jaas.conf"
 METRON_SPRING_OPTIONS="--kerberos.enabled=true"
 ```
+
 The metron-rest application will be available at http://node1:8082/swagger-ui.html#/.
 
 ## License


### PR DESCRIPTION
## Contributor Comments
There's also a problem on this page with code blocks after numeric list items.  They need to be indented so they don't cause restarts of the numbering.  This patch fixes them.  You may merge without attribution.

I've regenerated, and confirmed that while `site` takes longer than it used to, it works and returns within a reasonable amount of time.  Good work, Justin!

## Pull Request Checklist

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes: NA

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```
