### PR TITLE
Optimize various unit tests to reuse integration testing infrastructure rather than restarting every testcase

### DIFF
--- a/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/HBaseProfilerClientTest.java
+++ b/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/HBaseProfilerClientTest.java
@@ -20,11 +20,6 @@
 
 package org.apache.metron.profiler.client;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.HBaseTestingUtility;
-import org.apache.hadoop.hbase.client.HTableInterface;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.metron.profiler.ProfileMeasurement;
 import org.apache.metron.profiler.hbase.ColumnBuilder;
 import org.apache.metron.profiler.hbase.RowKeyBuilder;
@@ -32,6 +27,7 @@ import org.apache.metron.profiler.hbase.SaltyRowKeyBuilder;
 import org.apache.metron.profiler.hbase.ValueOnlyColumnBuilder;
 import org.apache.metron.profiler.stellar.DefaultStellarExecutor;
 import org.apache.metron.profiler.stellar.StellarExecutor;
+import org.apache.metron.test.mock.MockHTable;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -62,30 +58,14 @@ public class HBaseProfilerClientTest {
   private static final int periodsPerHour = 4;
 
   private HBaseProfilerClient client;
-  private HTableInterface table;
+  private MockHTable table;
   private StellarExecutor executor;
-  private static HBaseTestingUtility util;
   private ProfileWriter profileWriter;
-
-  @BeforeClass
-  public static void startHBase() throws Exception {
-    Configuration config = HBaseConfiguration.create();
-    config.set("hbase.master.hostname", "localhost");
-    config.set("hbase.regionserver.hostname", "localhost");
-    util = new HBaseTestingUtility(config);
-    util.startMiniCluster();
-  }
-
-  @AfterClass
-  public static void stopHBase() throws Exception {
-    util.shutdownMiniCluster();
-    util.cleanupTestDir();
-  }
 
   @Before
   public void setup() throws Exception {
 
-    table = util.createTable(Bytes.toBytes(tableName), Bytes.toBytes(columnFamily));
+    table = new MockHTable(tableName, columnFamily);
     executor = new DefaultStellarExecutor();
 
     // used to write values to be read during testing
@@ -99,7 +79,7 @@ public class HBaseProfilerClientTest {
 
   @After
   public void tearDown() throws Exception {
-    util.deleteTable(tableName);
+    table.clear();
   }
 
   /**

--- a/metron-platform/metron-data-management/src/test/java/org/apache/metron/dataloads/extractor/stix/StixExtractorTest.java
+++ b/metron-platform/metron-data-management/src/test/java/org/apache/metron/dataloads/extractor/stix/StixExtractorTest.java
@@ -83,33 +83,55 @@ public class StixExtractorTest {
     testStixAddresses(stixDocWithoutCondition);
   }
 
-  public void testStixAddresses(String stixDoc) throws Exception {
+  public void testStixAddresses(final String stixDoc) throws Exception {
+    Thread t1 = new Thread( () ->
     {
-      ExtractorHandler handler = ExtractorHandler.load(stixConfigOnlyIPV4);
-      Extractor extractor = handler.getExtractor();
-      Iterable<LookupKV> results = extractor.extract(stixDoc);
+      try {
+        ExtractorHandler handler = ExtractorHandler.load(stixConfigOnlyIPV4);
+        Extractor extractor = handler.getExtractor();
+        Iterable<LookupKV> results = extractor.extract(stixDoc);
 
-      Assert.assertEquals(3, Iterables.size(results));
-      Assert.assertEquals("10.0.0.0", ((EnrichmentKey)(Iterables.get(results, 0).getKey())).indicator);
-      Assert.assertEquals("10.0.0.1", ((EnrichmentKey)(Iterables.get(results, 1).getKey())).indicator);
-      Assert.assertEquals("10.0.0.2", ((EnrichmentKey)(Iterables.get(results, 2).getKey())).indicator);
-    }
+        Assert.assertEquals(3, Iterables.size(results));
+        Assert.assertEquals("10.0.0.0", ((EnrichmentKey) (Iterables.get(results, 0).getKey())).indicator);
+        Assert.assertEquals("10.0.0.1", ((EnrichmentKey) (Iterables.get(results, 1).getKey())).indicator);
+        Assert.assertEquals("10.0.0.2", ((EnrichmentKey) (Iterables.get(results, 2).getKey())).indicator);
+      }
+      catch(Exception ex) {
+        throw new RuntimeException(ex.getMessage(), ex);
+      }
+    });
+    Thread t2 = new Thread( () ->
     {
-
-      ExtractorHandler handler = ExtractorHandler.load(stixConfig);
-      Extractor extractor = handler.getExtractor();
-      Iterable<LookupKV> results = extractor.extract(stixDoc);
-      Assert.assertEquals(3, Iterables.size(results));
-      Assert.assertEquals("10.0.0.0", ((EnrichmentKey)(Iterables.get(results, 0).getKey())).indicator);
-      Assert.assertEquals("10.0.0.1", ((EnrichmentKey)(Iterables.get(results, 1).getKey())).indicator);
-      Assert.assertEquals("10.0.0.2", ((EnrichmentKey)(Iterables.get(results, 2).getKey())).indicator);
-    }
+      try {
+        ExtractorHandler handler = ExtractorHandler.load(stixConfig);
+        Extractor extractor = handler.getExtractor();
+        Iterable<LookupKV> results = extractor.extract(stixDoc);
+        Assert.assertEquals(3, Iterables.size(results));
+        Assert.assertEquals("10.0.0.0", ((EnrichmentKey) (Iterables.get(results, 0).getKey())).indicator);
+        Assert.assertEquals("10.0.0.1", ((EnrichmentKey) (Iterables.get(results, 1).getKey())).indicator);
+        Assert.assertEquals("10.0.0.2", ((EnrichmentKey) (Iterables.get(results, 2).getKey())).indicator);
+      }
+      catch(Exception ex) {
+        throw new RuntimeException(ex.getMessage(), ex);
+      }
+    });
+    Thread t3 = new Thread( () ->
     {
-
-      ExtractorHandler handler = ExtractorHandler.load(stixConfigOnlyIPV6);
-      Extractor extractor = handler.getExtractor();
-      Iterable<LookupKV> results = extractor.extract(stixDoc);
-      Assert.assertEquals(0, Iterables.size(results));
-    }
+      try {
+        ExtractorHandler handler = ExtractorHandler.load(stixConfigOnlyIPV6);
+        Extractor extractor = handler.getExtractor();
+        Iterable<LookupKV> results = extractor.extract(stixDoc);
+        Assert.assertEquals(0, Iterables.size(results));
+      }
+      catch(Exception ex) {
+        throw new RuntimeException(ex.getMessage(), ex);
+      }
+    });
+    t1.run();
+    t2.run();
+    t3.run();
+    t1.join();
+    t2.join();
+    t3.join();
   }
 }

--- a/metron-platform/metron-management/pom.xml
+++ b/metron-platform/metron-management/pom.xml
@@ -62,6 +62,10 @@
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
+                    <artifactId>commons-lang3</artifactId>
+                    <groupId>org.apache.commons</groupId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/ConfigurationFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/ConfigurationFunctionsTest.java
@@ -32,6 +32,7 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -42,14 +43,14 @@ import static org.apache.metron.management.utils.FileUtils.slurp;
 import static org.apache.metron.common.utils.StellarProcessorUtils.run;
 
 public class ConfigurationFunctionsTest {
-  private TestingServer testZkServer;
-  private CuratorFramework client;
-  private String zookeeperUrl;
+  private static TestingServer testZkServer;
+  private static CuratorFramework client;
+  private static String zookeeperUrl;
   private Context context = new Context.Builder()
             .with(Context.Capabilities.ZOOKEEPER_CLIENT, () -> client)
             .build();
-  @Before
-  public void setup() throws Exception {
+  @BeforeClass
+  public static void setup() throws Exception {
     testZkServer = new TestingServer(true);
     zookeeperUrl = testZkServer.getConnectString();
     client = ConfigurationsUtils.getClient(zookeeperUrl);
@@ -61,7 +62,7 @@ public class ConfigurationFunctionsTest {
 
   }
 
-  private void pushConfigs(String inputPath) throws Exception {
+  private static void pushConfigs(String inputPath) throws Exception {
     String[] args = new String[]{
             "-z", zookeeperUrl
             , "--mode", "PUSH"

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/FileSystemFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/FileSystemFunctionsTest.java
@@ -21,10 +21,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.metron.common.dsl.Context;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -37,8 +34,11 @@ import java.util.*;
 public class FileSystemFunctionsTest {
   private FileSystemFunctions.FS_TYPE type;
   private FileSystemFunctions.FileSystemGetter fsGetter = null;
-  private File baseDir;
-  private MiniDFSCluster hdfsCluster;
+  private static File hdfsBaseDir;
+  private static File localBaseDir;
+  private static MiniDFSCluster hdfsCluster;
+  private static String hdfsPrefix;
+  private static String localPrefix;
   private String prefix;
   private Context context = null;
   private FileSystemFunctions.FileSystemGet get;
@@ -59,25 +59,34 @@ public class FileSystemFunctionsTest {
     });
   }
 
+  @BeforeClass
+  public static void setupFS() throws IOException {
+    {
+      hdfsBaseDir = Files.createTempDirectory("test_hdfs").toFile().getAbsoluteFile();
+      Configuration conf = new Configuration();
+      conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, hdfsBaseDir.getAbsolutePath());
+      MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
+      hdfsCluster = builder.build();
+      hdfsPrefix = "/";
+    }
+    {
+      localPrefix = "target/fsTest/";
+      if (new File(localPrefix).exists()) {
+        new File(localPrefix).delete();
+      }
+      new File(localPrefix).mkdirs();
+    }
+  }
+
   @Before
   public void setup() throws IOException {
     if(type == FileSystemFunctions.FS_TYPE.HDFS) {
-      baseDir = Files.createTempDirectory("test_hdfs").toFile().getAbsoluteFile();
-      Configuration conf = new Configuration();
-      conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
-      MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
-      hdfsCluster = builder.build();
-
+      prefix=hdfsPrefix;
       fsGetter = () -> hdfsCluster.getFileSystem();
-      prefix = "/";
     }
     else {
+      prefix=localPrefix;
       fsGetter = FileSystemFunctions.FS_TYPE.LOCAL;
-      prefix = "target/fsTest/";
-      if(new File(prefix).exists()) {
-        new File(prefix).delete();
-      }
-      new File(prefix).mkdirs();
     }
 
     get = new FileSystemFunctions.FileSystemGet(fsGetter);
@@ -92,14 +101,14 @@ public class FileSystemFunctionsTest {
     rm.initialize(null);
   }
 
-  @After
-  public void teardown() {
-    if(type == FileSystemFunctions.FS_TYPE.HDFS) {
+  @AfterClass
+  public static void teardown() {
+    {
       hdfsCluster.shutdown();
-      FileUtil.fullyDelete(baseDir);
+      FileUtil.fullyDelete(hdfsBaseDir);
     }
-    else {
-      new File(prefix).delete();
+    {
+      new File(localPrefix).delete();
     }
   }
 

--- a/metron-platform/metron-parsers/pom.xml
+++ b/metron-platform/metron-parsers/pom.xml
@@ -166,6 +166,10 @@
                     <artifactId>slf4j-log4j12</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>commons-lang3</artifactId>
+                    <groupId>org.apache.commons</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is one of our costly unit tests (~70+s) and moving to a mock interface will drop it to 1s.