### PR TITLE
Add default charset for parsers and ability to configure read charset

### DIFF
--- a/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/BasicParser.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/BasicParser.java
@@ -19,6 +19,8 @@ package org.apache.metron.parsers;
 
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.Charset;
+import java.util.Map;
 import org.apache.metron.parsers.interfaces.MessageParser;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
@@ -29,6 +31,8 @@ public abstract class BasicParser implements
         Serializable {
 
   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private Charset readCharset;
 
   @Override
   public boolean validate(JSONObject message) {
@@ -65,5 +69,18 @@ public abstract class BasicParser implements
     } catch (Exception e) {
       return "0";
     }
+  }
+
+  public void setReadCharset(Map<String, Object> config) {
+    if (config.containsKey(READ_CHARSET)) {
+      readCharset = Charset.forName((String) config.get(READ_CHARSET));
+    } else {
+      readCharset = MessageParser.super.getReadCharset();
+    }
+  }
+
+  @Override
+  public Charset getReadCharset() {
+    return null == this.readCharset ? MessageParser.super.getReadCharset() : this.readCharset;
   }
 }

--- a/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/BasicParser.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/BasicParser.java
@@ -17,6 +17,11 @@
  */
 package org.apache.metron.parsers;
 
+import static org.apache.metron.common.Constants.Fields.DST_ADDR;
+import static org.apache.metron.common.Constants.Fields.ORIGINAL;
+import static org.apache.metron.common.Constants.Fields.SRC_ADDR;
+import static org.apache.metron.common.Constants.Fields.TIMESTAMP;
+
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.Charset;
@@ -37,11 +42,12 @@ public abstract class BasicParser implements
   @Override
   public boolean validate(JSONObject message) {
     JSONObject value = message;
-    if (!(value.containsKey("original_string"))) {
-      LOG.trace("[Metron] Message does not have original_string: {}", message);
+    final String invalidMessageTemplate = "[Metron] Message does not have {}: {}";
+    if (!(value.containsKey(ORIGINAL.getName()))) {
+      LOG.trace(invalidMessageTemplate, ORIGINAL.getName(), message);
       return false;
-    } else if (!(value.containsKey("timestamp"))) {
-      LOG.trace("[Metron] Message does not have timestamp: {}", message);
+    } else if (!(value.containsKey(TIMESTAMP.getName()))) {
+      LOG.trace(invalidMessageTemplate, TIMESTAMP.getName(), message);
       return false;
     } else {
       LOG.trace("[Metron] Message conforms to schema: {}", message);
@@ -53,10 +59,10 @@ public abstract class BasicParser implements
     try {
       String ipSrcAddr = null;
       String ipDstAddr = null;
-      if (value.containsKey("ip_src_addr"))
-        ipSrcAddr = value.get("ip_src_addr").toString();
-      if (value.containsKey("ip_dst_addr"))
-        ipDstAddr = value.get("ip_dst_addr").toString();
+      if (value.containsKey(SRC_ADDR.getName()))
+        ipSrcAddr = value.get(SRC_ADDR.getName()).toString();
+      if (value.containsKey(DST_ADDR.getName()))
+        ipDstAddr = value.get(DST_ADDR.getName()).toString();
       if (ipSrcAddr == null && ipDstAddr == null)
         return "0";
       if (ipSrcAddr == null || ipSrcAddr.length() == 0)

--- a/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/GrokParser.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/GrokParser.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -63,10 +64,12 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
   protected String timestampField;
   protected SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S z");
   protected String patternsCommonDir = "/patterns/common";
+  private Charset readCharset;
 
   @Override
   @SuppressWarnings("unchecked")
   public void configure(Map<String, Object> parserConfig) {
+    setReadCharset(parserConfig);
     this.grokPath = (String) parserConfig.get("grokPath");
     String multiLineString = (String) parserConfig.get("multiLine");
     if (!StringUtils.isBlank(multiLineString)) {
@@ -116,7 +119,7 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
                 "Unable to initialize grok parser: Unable to load " + patternsCommonDir + " from either classpath or HDFS");
       }
 
-      grok.addPatternFromReader(new InputStreamReader(commonInputStream, StandardCharsets.UTF_8));
+      grok.addPatternFromReader(new InputStreamReader(commonInputStream, getReadCharset()));
       LOG.info("Loading parser-specific patterns from: {}", grokPath);
 
       InputStream patterInputStream = openInputStream(grokPath);
@@ -124,7 +127,7 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
         throw new RuntimeException("Grok parser unable to initialize grok parser: Unable to load " + grokPath
                 + " from either classpath or HDFS");
       }
-      grok.addPatternFromReader(new InputStreamReader(patterInputStream, StandardCharsets.UTF_8));
+      grok.addPatternFromReader(new InputStreamReader(patterInputStream, getReadCharset()));
 
       LOG.info("Grok parser set the following grok expression for '{}': {}", patternLabel, grok.getPatterns().get(patternLabel));
 
@@ -158,7 +161,7 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
     String originalMessage = null;
     // read the incoming raw data as if it may have multiple lines of logs
     // if there is only only one line, it will just get processed.
-    try (BufferedReader reader = new BufferedReader(new StringReader(new String(rawMessage, StandardCharsets.UTF_8)))) {
+    try (BufferedReader reader = new BufferedReader(new StringReader(new String(rawMessage, getReadCharset())))) {
       while ((originalMessage = reader.readLine()) != null) {
         LOG.debug("Grok parser parsing message: {}", originalMessage);
         try {
@@ -289,6 +292,19 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
     } else {
       return Long.parseLong(Joiner.on("").join(Splitter.on('.').split(value + "")));
     }
+  }
+
+  public void setReadCharset(Map<String, Object> config) {
+    if (config.containsKey(READ_CHARSET)) {
+      readCharset = Charset.forName((String) config.get(READ_CHARSET));
+    } else {
+      readCharset = MessageParser.super.getReadCharset();
+    }
+  }
+
+  @Override
+  public Charset getReadCharset() {
+    return null == this.readCharset ? MessageParser.super.getReadCharset() : this.readCharset;
   }
 
 }

--- a/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/csv/CSVParser.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/csv/CSVParser.java
@@ -37,8 +37,10 @@ public class CSVParser extends BasicParser {
   public static final String TIMESTAMP_FORMAT_CONF = "timestampFormat";
   private transient CSVConverter converter;
   private SimpleDateFormat timestampFormat;
+
   @Override
   public void configure(Map<String, Object> parserConfig) {
+    setReadCharset(parserConfig);
     converter = new CSVConverter();
     converter.initialize(parserConfig);
     Object tsFormatObj = parserConfig.get(TIMESTAMP_FORMAT_CONF);
@@ -56,7 +58,7 @@ public class CSVParser extends BasicParser {
   @Override
   public List<JSONObject> parse(byte[] rawMessage) {
     try {
-      String msg = new String(rawMessage, StandardCharsets.UTF_8);
+      String msg = new String(rawMessage, getReadCharset());
       Map<String, String> value = converter.toMap(msg);
       if(value != null) {
         value.put("original_string", msg);

--- a/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/csv/CSVParser.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/csv/CSVParser.java
@@ -20,14 +20,13 @@ package org.apache.metron.parsers.csv;
 
 import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandles;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.metron.common.csv.CSVConverter;
-import org.apache.metron.stellar.common.utils.ConversionUtils;
 import org.apache.metron.parsers.BasicParser;
+import org.apache.metron.stellar.common.utils.ConversionUtils;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +89,7 @@ public class CSVParser extends BasicParser {
         return Collections.emptyList();
       }
     } catch (Throwable e) {
-      String message = "Unable to parse " + new String(rawMessage, StandardCharsets.UTF_8) + ": " + e.getMessage();
+      String message = "Unable to parse " + new String(rawMessage, getReadCharset()) + ": " + e.getMessage();
       LOG.error(message, e);
       throw new IllegalStateException(message, e);
     }

--- a/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/interfaces/MessageParser.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/interfaces/MessageParser.java
@@ -17,17 +17,17 @@
  */
 package org.apache.metron.parsers.interfaces;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.metron.parsers.DefaultMessageParserResult;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 public interface MessageParser<T> extends Configurable {
+
+  String READ_CHARSET = "readCharset"; // property to use for getting the read charset from parser config
+
   /**
    * Initialize the message parser.  This is done once.
    */
@@ -81,4 +81,11 @@ public interface MessageParser<T> extends Configurable {
    */
   boolean validate(T message);
 
+  /**
+   * Provides a hook to override the default charset parsers use to read data.
+   * @return Charset to use for for reading
+   */
+  default Charset getReadCharset() {
+    return StandardCharsets.UTF_8;
+  }
 }

--- a/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/json/JSONMapParser.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/json/JSONMapParser.java
@@ -106,6 +106,7 @@ public class JSONMapParser extends BasicParser {
 
   @Override
   public void configure(Map<String, Object> config) {
+    setReadCharset(config);
     String strategyStr = (String) config.getOrDefault(MAP_STRATEGY_CONFIG, MapStrategy.DROP.name());
     mapStrategy = MapStrategy.valueOf(strategyStr);
     overrideOriginalString = (Boolean) config.getOrDefault(OVERRIDE_ORIGINAL_STRING, false);
@@ -170,7 +171,7 @@ public class JSONMapParser extends BasicParser {
   @SuppressWarnings("unchecked")
   public List<JSONObject> parse(byte[] rawMessage) {
     try {
-      String rawString = new String(rawMessage, StandardCharsets.UTF_8);
+      String rawString = new String(rawMessage, getReadCharset());
       List<Map<String, Object>> messages = new ArrayList<>();
 
       // if configured, wrap the json in an entity and array

--- a/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/regex/RegularExpressionsParser.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/main/java/org/apache/metron/parsers/regex/RegularExpressionsParser.java
@@ -16,20 +16,25 @@
 package org.apache.metron.parsers.regex;
 
 import com.google.common.base.CaseFormat;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.metron.common.Constants;
 import org.apache.metron.parsers.BasicParser;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.invoke.MethodHandles;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 //@formatter:off
 /**
@@ -154,7 +159,7 @@ public class RegularExpressionsParser extends BasicParser {
     public List<JSONObject> parse(byte[] rawMessage) {
         String originalMessage = null;
         try {
-            originalMessage = new String(rawMessage, StandardCharsets.UTF_8).trim();
+            originalMessage = new String(rawMessage, getReadCharset()).trim();
             LOG.debug(" raw message. {}", originalMessage);
             if (originalMessage.isEmpty()) {
                 LOG.warn("Message is empty.");
@@ -201,6 +206,7 @@ public class RegularExpressionsParser extends BasicParser {
   // @formatter:on
   @Override
   public void configure(Map<String, Object> parserConfig) {
+      setReadCharset(parserConfig);
       setParserConfig(parserConfig);
       setFields((List<Map<String, Object>>) getParserConfig()
           .get(ParserConfigConstants.FIELDS.getName()));

--- a/metron-platform/metron-parsing/metron-parsers-common/src/test/java/org/apache/metron/parsers/BasicParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/test/java/org/apache/metron/parsers/BasicParserTest.java
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.parsers;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.io.FileUtils;
+import org.apache.metron.parsers.interfaces.MessageParser;
+import org.apache.metron.parsers.interfaces.MessageParserResult;
+import org.json.simple.JSONObject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class BasicParserTest {
+
+  private static final String KEY1 = "key1";
+
+  private static class SomeParserWithCharset extends BasicParser {
+
+    @Override
+    public void init() {
+
+    }
+
+    @Override
+    public void configure(Map<String, Object> config) {
+      setReadCharset(config);
+    }
+
+    @Override
+    public Optional<MessageParserResult<JSONObject>> parseOptionalResult(byte[] parseMessage) {
+      String message = new String(parseMessage, getReadCharset());
+      Map<String, Object> out = new HashMap<>();
+      out.put(KEY1, message);
+      MessageParserResult<JSONObject> result = new DefaultMessageParserResult<JSONObject>(
+          Arrays.asList(new JSONObject(out)));
+      return Optional.of(result);
+    }
+  }
+
+  private static class SomeParserNoCharset extends SomeParserWithCharset {
+    @Override
+    public void configure(Map<String, Object> config) {
+      // don't set the charset
+    }
+  }
+
+
+  private static final String SAMPLE_DATA = "Here is some sample data";
+  private SomeParserWithCharset parserWithCharset;
+  private SomeParserNoCharset parserNoCharset;
+  private Map<String, Object> parserConfig;
+  private File fileUTF_16;
+  private File fileUTF_8;
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Before
+  public void setup() throws IOException, InterruptedException {
+    tempFolder.create();
+    parserWithCharset = new SomeParserWithCharset();
+    parserNoCharset = new SomeParserNoCharset();
+    parserConfig = new HashMap<>();
+    fileUTF_16 = new File(tempFolder.getRoot(), "fileUTF-16");
+    fileUTF_8 = new File(tempFolder.getRoot(), "fileUTF-8");
+    writeDataEncodedAs(fileUTF_16, SAMPLE_DATA, StandardCharsets.UTF_16);
+    writeDataEncodedAs(fileUTF_8, SAMPLE_DATA, StandardCharsets.UTF_8);
+  }
+
+  private void writeDataEncodedAs(File file, String data, Charset charset) throws IOException {
+    byte[] bytes = data.getBytes(charset);
+    FileUtils.writeByteArrayToFile(file, bytes);
+  }
+
+  @Test
+  public void verify_encoding_translation_assumptions() throws IOException {
+    // read in file encoded as UTF_16 bytes to a String using UTF_8 and UTF_16 encoding
+    // the UTF_8 translation here should be a garbled mess because UTF_16 needs to have a
+    // translation step for it to be correct in UTF_8
+    String utf16_8 = readDataEncodedAs(fileUTF_16, StandardCharsets.UTF_8);
+    String utf16_16 = readDataEncodedAs(fileUTF_16, StandardCharsets.UTF_16);
+    File utf16_16_8 = new File(tempFolder.getRoot(), "outUTF-8");
+    writeDataEncodedAs(utf16_16_8, utf16_16, StandardCharsets.UTF_8);
+    String utf8_8 = readDataEncodedAs(utf16_16_8, StandardCharsets.UTF_8);
+    assertThat(utf8_8, equalTo(utf16_16));
+    assertThat(utf8_8, not(equalTo(utf16_8)));
+
+    assertThat(utf8_8, equalTo(utf16_16));
+    assertThat(utf8_8, not(equalTo(utf16_8)));
+  }
+
+  private String readDataEncodedAs(File file, Charset charset) throws IOException {
+    return FileUtils.readFileToString(file, charset);
+  }
+
+  @Test
+  public void parses_with_specified_encoding() {
+    parserConfig.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    parserWithCharset.configure(parserConfig);
+    Optional<MessageParserResult<JSONObject>> result = parserWithCharset
+        .parseOptionalResult(SAMPLE_DATA.getBytes(StandardCharsets.UTF_16));
+    MessageParserResult<JSONObject> json = result.get();
+    assertThat(json.getMessages().size(), equalTo(1));
+    assertThat(json.getMessages().get(0).get(KEY1), equalTo(SAMPLE_DATA));
+  }
+
+  @Test
+  public void values_will_not_match_when_specified_encoding_is_wrong() {
+    parserConfig.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_8.toString());
+    parserWithCharset.configure(parserConfig);
+    Optional<MessageParserResult<JSONObject>> result = parserWithCharset
+        .parseOptionalResult(SAMPLE_DATA.getBytes(StandardCharsets.UTF_16));
+    MessageParserResult<JSONObject> json = result.get();
+    assertThat(json.getMessages().size(), equalTo(1));
+    assertThat(json.getMessages().get(0).get(KEY1), not(equalTo(SAMPLE_DATA)));
+  }
+
+  @Test
+  public void parses_with_default_encoding_when_not_configured() {
+    parserWithCharset.configure(parserConfig);
+    Optional<MessageParserResult<JSONObject>> result = parserWithCharset
+        .parseOptionalResult(SAMPLE_DATA.getBytes(StandardCharsets.UTF_8));
+    MessageParserResult<JSONObject> json = result.get();
+    assertThat(json.getMessages().size(), equalTo(1));
+    assertThat(json.getMessages().get(0).get(KEY1), equalTo(SAMPLE_DATA));
+  }
+
+  @Test
+  public void parses_with_default_encoding_from_basic_parser() {
+    parserNoCharset.configure(parserConfig);
+    Optional<MessageParserResult<JSONObject>> result = parserNoCharset
+        .parseOptionalResult(SAMPLE_DATA.getBytes(StandardCharsets.UTF_8));
+    MessageParserResult<JSONObject> json = result.get();
+    assertThat(json.getMessages().size(), equalTo(1));
+    assertThat(json.getMessages().get(0).get(KEY1), equalTo(SAMPLE_DATA));
+  }
+
+}

--- a/metron-platform/metron-parsing/metron-parsers-common/src/test/java/org/apache/metron/parsers/ParserRunnerImplTest.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/test/java/org/apache/metron/parsers/ParserRunnerImplTest.java
@@ -312,7 +312,7 @@ public class ParserRunnerImplTest {
     inputMessage.put("guid", "guid");
     inputMessage.put("ip_src_addr", "192.168.1.1");
     inputMessage.put("ip_dst_addr", "192.168.1.2");
-    RawMessage rawMessage = new RawMessage("raw_message".getBytes(StandardCharsets.UTF_8), new HashMap<>());
+    RawMessage rawMessage = new RawMessage("raw_message_for_testing".getBytes(StandardCharsets.UTF_8), new HashMap<>());
 
     JSONObject expectedOutput  = new JSONObject();
     expectedOutput.put("guid", "guid");

--- a/metron-platform/metron-parsing/metron-parsers-common/src/test/java/org/apache/metron/parsers/csv/CSVParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/test/java/org/apache/metron/parsers/csv/CSVParserTest.java
@@ -18,18 +18,22 @@
 
 package org.apache.metron.parsers.csv;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Level;
 import org.apache.metron.common.configuration.SensorParserConfig;
 import org.apache.metron.common.utils.JSONUtils;
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.apache.metron.test.utils.UnitTestHelper;
 import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.List;
 
 public class CSVParserTest {
   /**
@@ -120,5 +124,24 @@ public class CSVParserTest {
       catch(IllegalStateException iae) {}
       UnitTestHelper.setLog4jLevel(CSVParser.class, Level.ERROR);
     }
+  }
+
+  @Test
+  public void getsReadCharsetFromConfig() throws IOException {
+    SensorParserConfig config = JSONUtils.INSTANCE.load(parserConfig, SensorParserConfig.class);
+    CSVParser parser = new CSVParser();
+    parser.init();
+    config.getParserConfig().put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    parser.configure(config.getParserConfig());
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() throws IOException {
+    SensorParserConfig config = JSONUtils.INSTANCE.load(parserConfig, SensorParserConfig.class);
+    CSVParser parser = new CSVParser();
+    parser.init();
+    parser.configure(config.getParserConfig());
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
   }
 }

--- a/metron-platform/metron-parsing/metron-parsers-common/src/test/java/org/apache/metron/parsers/regex/RegularExpressionsParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers-common/src/test/java/org/apache/metron/parsers/regex/RegularExpressionsParserTest.java
@@ -14,17 +14,21 @@
  */
 package org.apache.metron.parsers.regex;
 
-import java.nio.charset.StandardCharsets;
-import org.adrianwalker.multilinestring.Multiline;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.adrianwalker.multilinestring.Multiline;
+import org.apache.metron.parsers.interfaces.MessageParser;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 public class RegularExpressionsParserTest {
 
@@ -274,4 +278,20 @@ public class RegularExpressionsParserTest {
         }
         throw new Exception("Could not parse : " + message);
     }
+
+    @Test
+    public void getsReadCharsetFromConfig() throws ParseException {
+        JSONObject config = (JSONObject) new JSONParser().parse(parserConfig1);
+        config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+        regularExpressionsParser.configure(config);
+        assertThat(regularExpressionsParser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+    }
+
+    @Test
+    public void getsReadCharsetFromDefault() throws ParseException {
+      JSONObject config = (JSONObject) new JSONParser().parse(parserConfig1);
+      regularExpressionsParser.configure(config);
+      assertThat(regularExpressionsParser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
+    }
+
 }

--- a/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/asa/BasicAsaParser.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/asa/BasicAsaParser.java
@@ -20,7 +20,6 @@ package org.apache.metron.parsers.asa;
 import com.google.common.collect.ImmutableMap;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
@@ -97,6 +96,7 @@ public class BasicAsaParser extends BasicParser {
 
   @Override
   public void configure(Map<String, Object> parserConfig) {
+    setReadCharset(parserConfig);
     String timeZone = (String) parserConfig.get("deviceTimeZone");
     if (timeZone != null)
       deviceClock = Clock.system(ZoneId.of(timeZone));

--- a/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/bro/BasicBroParser.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/bro/BasicBroParser.java
@@ -19,7 +19,6 @@
 package org.apache.metron.parsers.bro;
 
 import java.lang.invoke.MethodHandles;
-import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -46,7 +45,7 @@ public class BasicBroParser extends BasicParser {
 
   @Override
   public void configure(Map<String, Object> parserConfig) {
-
+    setReadCharset(parserConfig);
   }
 
   @Override
@@ -63,7 +62,7 @@ public class BasicBroParser extends BasicParser {
     String rawMessage = null;
     List<JSONObject> messages = new ArrayList<>();
     try {
-      rawMessage = new String(msg, StandardCharsets.UTF_8);
+      rawMessage = new String(msg, getReadCharset());
       _LOG.trace("[Metron] Received message: {}", rawMessage);
 
       JSONObject cleanedMessage = cleaner.clean(rawMessage);

--- a/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/cef/CEFParser.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/cef/CEFParser.java
@@ -19,8 +19,6 @@
 package org.apache.metron.parsers.cef;
 
 import java.lang.invoke.MethodHandles;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -144,7 +142,7 @@ public class CEFParser extends BasicParser {
 	public List<JSONObject> parse(byte[] rawMessage) {
 		List<JSONObject> messages = new ArrayList<>();
 
-		String cefString = new String(rawMessage, StandardCharsets.UTF_8);
+		String cefString = new String(rawMessage, getReadCharset());
 
 		Matcher matcher = p.matcher(cefString);
 
@@ -260,6 +258,7 @@ public class CEFParser extends BasicParser {
 
 	@Override
 	public void configure(Map<String, Object> config) {
+	  setReadCharset(config);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/fireeye/BasicFireEyeParser.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/fireeye/BasicFireEyeParser.java
@@ -55,7 +55,9 @@ public class BasicFireEyeParser extends BasicParser {
   private static final Pattern nvPattern = Pattern.compile(nvRegex);
 
   @Override
-  public void configure(Map<String, Object> parserConfig) {}
+  public void configure(Map<String, Object> parserConfig) {
+    setReadCharset(parserConfig);
+  }
 
   @Override
   public void init() {}
@@ -68,7 +70,7 @@ public class BasicFireEyeParser extends BasicParser {
     List<JSONObject> messages = new ArrayList<>();
     try {
 
-      toParse = new String(rawMessage, StandardCharsets.UTF_8);
+      toParse = new String(rawMessage, getReadCharset());
 
       // because we support what is basically a malformed syslog 3164 message having
       // some form of text before the PRIORITY, we need to use the priority as

--- a/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/ise/BasicIseParser.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/ise/BasicIseParser.java
@@ -20,16 +20,14 @@
 package org.apache.metron.parsers.ise;
 
 import com.esotericsoftware.minlog.Log;
-import java.nio.charset.StandardCharsets;
-import org.apache.metron.parsers.BasicParser;
-import org.json.simple.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.metron.parsers.BasicParser;
+import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("serial")
 public class BasicIseParser extends BasicParser {
@@ -40,7 +38,7 @@ public class BasicIseParser extends BasicParser {
 
 	@Override
 	public void configure(Map<String, Object> parserConfig) {
-
+    setReadCharset(parserConfig);
 	}
 
 	@Override
@@ -56,7 +54,7 @@ public class BasicIseParser extends BasicParser {
 		List<JSONObject> messages = new ArrayList<>();
 		try {
 
-			raw_message = new String(msg, StandardCharsets.UTF_8);
+			raw_message = new String(msg, getReadCharset());
 			_LOG.debug("Received message: {}", raw_message);
 
 			/*

--- a/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/lancope/BasicLancopeParser.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/lancope/BasicLancopeParser.java
@@ -19,7 +19,6 @@
 package org.apache.metron.parsers.lancope;
 
 import java.lang.invoke.MethodHandles;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -40,7 +39,7 @@ public class BasicLancopeParser extends BasicParser {
 
 	@Override
 	public void configure(Map<String, Object> parserConfig) {
-
+    setReadCharset(parserConfig);
 	}
 
 	@Override
@@ -56,7 +55,7 @@ public class BasicLancopeParser extends BasicParser {
 		List<JSONObject> messages = new ArrayList<>();
 		try {
 			
-			String raw_message = new String(msg, StandardCharsets.UTF_8);
+			String raw_message = new String(msg, getReadCharset());
 			
 			payload = (JSONObject) JSONValue.parse(raw_message);
 			

--- a/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/leef/LEEFParser.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/leef/LEEFParser.java
@@ -21,8 +21,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.invoke.MethodHandles;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.util.ArrayList;
@@ -32,7 +30,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.apache.metron.common.Constants.Fields;
 import org.apache.metron.parsers.BasicParser;
 import org.apache.metron.parsers.DefaultMessageParserResult;
@@ -137,7 +134,7 @@ public class LEEFParser extends BasicParser {
     Map<Object,Throwable> errors = new HashMap<>();
     String originalMessage = null;
 
-    try (BufferedReader reader = new BufferedReader(new StringReader(new String(rawMessage, StandardCharsets.UTF_8)))) {
+    try (BufferedReader reader = new BufferedReader(new StringReader(new String(rawMessage, getReadCharset())))) {
       while ((originalMessage = reader.readLine()) != null) {
         Matcher matcher = pattern.matcher(originalMessage);
         while (matcher.find()) {
@@ -272,6 +269,7 @@ public class LEEFParser extends BasicParser {
 
   @Override
   public void configure(Map<String, Object> config) {
+    setReadCharset(config);
   }
 
   @SuppressWarnings("unchecked")

--- a/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/paloalto/BasicPaloAltoFirewallParser.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/paloalto/BasicPaloAltoFirewallParser.java
@@ -20,18 +20,16 @@ package org.apache.metron.parsers.paloalto;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
-import java.nio.charset.StandardCharsets;
-import org.apache.metron.parsers.BasicParser;
-import org.json.simple.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import org.apache.metron.parsers.BasicParser;
+import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BasicPaloAltoFirewallParser extends BasicParser {
 
@@ -161,7 +159,7 @@ public class BasicPaloAltoFirewallParser extends BasicParser {
 
   @Override
   public void configure(Map<String, Object> parserConfig) {
-
+    setReadCharset(parserConfig);
   }
 
   @Override
@@ -178,7 +176,7 @@ public class BasicPaloAltoFirewallParser extends BasicParser {
     List<JSONObject> messages = new ArrayList<>();
     try {
 
-      toParse = new String(msg, StandardCharsets.UTF_8);
+      toParse = new String(msg, getReadCharset());
       _LOG.debug("Received message: {}", toParse);
       parseMessage(toParse, outputMessage);
       long timestamp = System.currentTimeMillis();

--- a/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/snort/BasicSnortParser.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/snort/BasicSnortParser.java
@@ -91,6 +91,7 @@ public class BasicSnortParser extends BasicParser {
 
   @Override
   public void configure(Map<String, Object> parserConfig) {
+    setReadCharset(parserConfig);
     dateTimeFormatter = getDateFormatter(parserConfig);
     dateTimeFormatter = getDateFormatterWithZone(dateTimeFormatter, parserConfig);
     init();
@@ -140,7 +141,7 @@ public class BasicSnortParser extends BasicParser {
     List<JSONObject> messages = new ArrayList<>();
     try {
       // snort alerts expected as csv records
-      String csvMessage = new String(rawMessage, StandardCharsets.UTF_8);
+      String csvMessage = new String(rawMessage, getReadCharset());
       Map<String, String> records = null;
       try {
          records = converter.toMap(csvMessage);

--- a/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/sourcefire/BasicSourcefireParser.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/main/java/org/apache/metron/parsers/sourcefire/BasicSourcefireParser.java
@@ -18,7 +18,6 @@
 
 package org.apache.metron.parsers.sourcefire;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +43,7 @@ public class BasicSourcefireParser extends BasicParser {
 
 	@Override
 	public void configure(Map<String, Object> parserConfig) {
-
+	  setReadCharset(parserConfig);
 	}
 
 	@Override
@@ -61,7 +60,7 @@ public class BasicSourcefireParser extends BasicParser {
 		List<JSONObject> messages = new ArrayList<>();
 		try {
 
-			toParse = new String(msg, StandardCharsets.UTF_8);
+			toParse = new String(msg, getReadCharset());
 			_LOG.debug("Received message: {}", toParse);
 
 			String tmp = toParse.substring(toParse.lastIndexOf("{"));

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/SnortParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/SnortParserTest.java
@@ -18,25 +18,25 @@
 
 package org.apache.metron.parsers;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.log4j.Level;
 import org.apache.metron.common.Constants;
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.apache.metron.parsers.snort.BasicSnortParser;
 import org.apache.metron.test.utils.UnitTestHelper;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import java.time.ZoneId;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TimeZone;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
 
 public class SnortParserTest {
 
@@ -148,4 +148,20 @@ public class SnortParserTest {
     parser.configure(parserConfig);
   }
 
+  @Test
+  public void getsReadCharsetFromConfig() {
+    Map<String, Object> config = new HashMap<>();
+    config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    BasicSnortParser parser = new BasicSnortParser();
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() {
+    Map<String, Object> config = new HashMap<>();
+    BasicSnortParser parser = new BasicSnortParser();
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
+  }
 }

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/asa/BasicAsaParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/asa/BasicAsaParserTest.java
@@ -17,29 +17,37 @@
  */
 package org.apache.metron.parsers.asa;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.log4j.Level;
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.apache.metron.test.utils.UnitTestHelper;
 import org.json.simple.JSONObject;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.time.*;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.*;
-
 public class BasicAsaParserTest {
 
     private static BasicAsaParser asaParser;
+    private Map<String, Object> parserConfig;
 
-    @BeforeClass
-    public static void setUpOnce() throws Exception {
-        Map<String, Object> parserConfig = new HashMap<>();
+    @Before
+    public void setUp() throws Exception {
+        parserConfig = new HashMap<>();
         asaParser = new BasicAsaParser();
         asaParser.configure(parserConfig);
         asaParser.init();
@@ -47,7 +55,6 @@ public class BasicAsaParserTest {
 
     @Test
     public void testConfigureDefault() {
-        Map<String, Object> parserConfig = new HashMap<>();
         BasicAsaParser testParser = new BasicAsaParser();
         testParser.configure(parserConfig);
         testParser.init();
@@ -56,7 +63,6 @@ public class BasicAsaParserTest {
 
     @Test
     public void testConfigureTimeZoneOffset() {
-        Map<String, Object> parserConfig = new HashMap<>();
         parserConfig.put("deviceTimeZone", "UTC-05:00");
         BasicAsaParser testParser = new BasicAsaParser();
         testParser.configure(parserConfig);
@@ -68,7 +74,6 @@ public class BasicAsaParserTest {
 
     @Test
     public void testConfigureTimeZoneText() {
-        Map<String, Object> parserConfig = new HashMap<>();
         parserConfig.put("deviceTimeZone", "America/New_York");
         BasicAsaParser testParser = new BasicAsaParser();
         testParser.configure(parserConfig);
@@ -185,5 +190,18 @@ public class BasicAsaParserTest {
         thrown.expectMessage(startsWith("[Metron] Message '-- MARK --'"));
         JSONObject asaJson = asaParser.parse(rawMessage.getBytes(StandardCharsets.UTF_8)).get(0);
         UnitTestHelper.setLog4jLevel(BasicAsaParser.class, Level.ERROR);
+    }
+
+    @Test
+    public void getsReadCharsetFromConfig() {
+      parserConfig.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+      asaParser.configure(parserConfig);
+      assertThat(asaParser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+    }
+
+    @Test
+    public void getsReadCharsetFromDefault() {
+      asaParser.configure(parserConfig);
+      assertThat(asaParser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
     }
 }

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/bro/BasicBroParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/bro/BasicBroParserTest.java
@@ -17,10 +17,16 @@
  */
 package org.apache.metron.parsers.bro;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Level;
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.apache.metron.test.utils.UnitTestHelper;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -28,8 +34,6 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.AfterClass;
 import org.junit.Assert;
-
-import java.util.Map;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -1423,4 +1427,19 @@ public class BasicBroParserTest {
 	public void testBadMessageNonJson() {
 		broParser.parse("foo bar".getBytes(StandardCharsets.UTF_8));
 	}
+
+  @Test
+  public void getsReadCharsetFromConfig() {
+	  Map<String, Object> config = new HashMap<>();
+    config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    broParser.configure(config);
+    assertThat(broParser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() {
+    Map<String, Object> config = new HashMap<>();
+    broParser.configure(config);
+    assertThat(broParser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
+  }
 }

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/cef/CEFParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/cef/CEFParserTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.metron.parsers.cef;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,21 +29,22 @@ import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import com.github.fge.jsonschema.main.JsonValidator;
 import com.google.common.io.Resources;
-import org.apache.metron.common.Constants.Fields;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.metron.common.Constants.Fields;
+import org.apache.metron.parsers.interfaces.MessageParser;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 public class CEFParserTest {
 	private CEFParser parser;
@@ -275,5 +279,20 @@ public class CEFParserTest {
 		Assert.assertNotNull(parse);
 		return parse;
 	}
+
+  @Test
+  public void getsReadCharsetFromConfig() {
+    Map<String, Object> config = new HashMap<>();
+    config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() {
+    Map<String, Object> config = new HashMap<>();
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
+  }
 
 }

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/fireeye/BasicFireEyeParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/fireeye/BasicFireEyeParserTest.java
@@ -17,14 +17,18 @@
  */
 package org.apache.metron.parsers.fireeye;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.nio.charset.StandardCharsets;
+import java.time.Year;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.time.Year;
-import java.time.ZonedDateTime;
-import java.time.ZoneOffset;
-
 import org.apache.metron.parsers.AbstractParserConfigTest;
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -73,5 +77,20 @@ public class BasicFireEyeParserTest extends AbstractParserConfigTest {
     Map json = (Map) parser.parse(parsed.toJSONString());
     long expectedTimestamp = ZonedDateTime.of(Year.now(ZoneOffset.UTC).getValue(), 3, 19, 5, 24, 39, 0, ZoneOffset.UTC).toInstant().toEpochMilli();
     Assert.assertEquals(expectedTimestamp, json.get("timestamp"));
+  }
+
+  @Test
+  public void getsReadCharsetFromConfig() {
+    Map<String, Object> config = new HashMap<>();
+    config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() {
+    Map<String, Object> config = new HashMap<>();
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
   }
 }

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/ise/BasicIseParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/ise/BasicIseParserTest.java
@@ -17,12 +17,17 @@
  */
 package org.apache.metron.parsers.ise;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.metron.parsers.AbstractParserConfigTest;
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.Assert;
@@ -53,5 +58,20 @@ public class BasicIseParserTest extends AbstractParserConfigTest {
       Map<?, ?> json = (Map<?, ?>) parser.parse(parsed.toJSONString());
       Assert.assertTrue(validateJsonData(getSchemaJsonString(), json.toString()));
     }
+  }
+  
+  @Test
+  public void getsReadCharsetFromConfig() {
+    Map<String, Object> config = new HashMap<>();
+    config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() {
+    Map<String, Object> config = new HashMap<>();
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
   }
 }

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/lancope/BasicLancopeParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/lancope/BasicLancopeParserTest.java
@@ -17,12 +17,17 @@
  */
 package org.apache.metron.parsers.lancope;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.metron.parsers.AbstractParserConfigTest;
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -53,6 +58,21 @@ public class BasicLancopeParserTest extends AbstractParserConfigTest {
       Map<?, ?> json = (Map<?, ?>) parser.parse(parsed.toJSONString());
       Assert.assertTrue(validateJsonData(getSchemaJsonString(), json.toString()));
     }
+  }
+
+  @Test
+  public void getsReadCharsetFromConfig() {
+    Map<String, Object> config = new HashMap<>();
+    config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() {
+    Map<String, Object> config = new HashMap<>();
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
   }
 }
 

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/leef/LEEFParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/leef/LEEFParserTest.java
@@ -17,27 +17,34 @@
  */
 package org.apache.metron.parsers.leef;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JsonLoader;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import com.github.fge.jsonschema.main.JsonValidator;
 import com.google.common.io.Resources;
+import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.metron.common.Constants.Fields;
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.apache.metron.parsers.interfaces.MessageParserResult;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.nio.charset.StandardCharsets;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 public class LEEFParserTest {
   private LEEFParser parser;
@@ -236,5 +243,20 @@ public class LEEFParserTest {
     Optional<MessageParserResult<JSONObject>> parse = parser.parseOptionalResult(string.getBytes(StandardCharsets.UTF_8));
     Assert.assertTrue(parse.isPresent());
     return parse.get().getMessages();
+  }
+
+  @Test
+  public void getsReadCharsetFromConfig() {
+    Map<String, Object> config = new HashMap<>();
+    config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() {
+    Map<String, Object> config = new HashMap<>();
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
   }
 }

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/paloalto/BasicPaloAltoFirewallParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/paloalto/BasicPaloAltoFirewallParserTest.java
@@ -17,17 +17,21 @@
  */
 package org.apache.metron.parsers.paloalto;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.metron.parsers.AbstractParserConfigTest;
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.List;
 
 public class BasicPaloAltoFirewallParserTest extends AbstractParserConfigTest {
 
@@ -752,5 +756,20 @@ public class BasicPaloAltoFirewallParserTest extends AbstractParserConfigTest {
     JSONObject actual = parser.parse(invalidLengthMessage.getBytes(StandardCharsets.UTF_8)).get(0);
     String expectedParserVersion = actual.get(BasicPaloAltoFirewallParser.ParserVersion).toString();
     assertEquals(expectedParserVersion, "0");
+  }
+
+  @Test
+  public void getsReadCharsetFromConfig() {
+    Map<String, Object> config = new HashMap<>();
+    config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() {
+    Map<String, Object> config = new HashMap<>();
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
   }
 }

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/sourcefire/BasicSourcefireParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/sourcefire/BasicSourcefireParserTest.java
@@ -17,10 +17,15 @@
  */
 package org.apache.metron.parsers.sourcefire;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.metron.parsers.AbstractParserConfigTest;
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -55,5 +60,20 @@ public class BasicSourcefireParserTest extends AbstractParserConfigTest {
         Assert.assertNotNull(value);
       }
     }
+  }
+
+  @Test
+  public void getsReadCharsetFromConfig() {
+    Map<String, Object> config = new HashMap<>();
+    config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() {
+    Map<String, Object> config = new HashMap<>();
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
   }
 }

--- a/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/websphere/GrokWebSphereParserTest.java
+++ b/metron-platform/metron-parsing/metron-parsers/src/test/java/org/apache/metron/parsers/websphere/GrokWebSphereParserTest.java
@@ -18,15 +18,19 @@
 
 package org.apache.metron.parsers.websphere;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import java.nio.charset.StandardCharsets;
-import java.time.*;
+import java.time.Year;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
+import org.apache.metron.parsers.interfaces.MessageParser;
 import org.apache.metron.parsers.interfaces.MessageParserResult;
 import org.json.simple.JSONObject;
 import org.junit.Assert;
@@ -37,6 +41,7 @@ public class GrokWebSphereParserTest {
 
 	private static final ZoneId UTC = ZoneId.of("UTC");
 	private Map<String, Object> parserConfig;
+	private GrokWebSphereParser parser;
 
 	@Before
 	public void setup() {
@@ -45,14 +50,12 @@ public class GrokWebSphereParserTest {
 		parserConfig.put("patternLabel", "WEBSPHERE");
 		parserConfig.put("timestampField", "timestamp_string");
 		parserConfig.put("dateFormat", "yyyy MMM dd HH:mm:ss");
+    parser = new GrokWebSphereParser();
+    parser.configure(parserConfig);
 	}
 	
 	@Test
 	public void testParseLoginLine() throws Exception {
-		
-		//Set up parser, parse message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
-		parser.configure(parserConfig);
 		String testString = "<133>Apr 15 17:47:28 ABCXML1413 [rojOut][0x81000033][auth][notice] user(rick007): "
 				+ "[120.43.200.6]: User logged into 'cohlOut'.";
 		Optional<MessageParserResult<JSONObject>> resultOptional = parser.parseOptionalResult(testString.getBytes(
@@ -79,10 +82,6 @@ public class GrokWebSphereParserTest {
 	
 	@Test
 	public void testParseLogoutLine() throws Exception {
-		
-		//Set up parser, parse message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
-		parser.configure(parserConfig);
 		String testString = "<134>Apr 15 18:02:27 PHIXML3RWD [0x81000019][auth][info] [14.122.2.201]: "
 				+ "User 'hjpotter' logged out from 'default'.";
 		Optional<MessageParserResult<JSONObject>> resultOptional = parser.parseOptionalResult(testString.getBytes(
@@ -108,10 +107,6 @@ public class GrokWebSphereParserTest {
 	
 	@Test
 	public void testParseRBMLine() throws Exception {
-		
-		//Set up parser, parse message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
-		parser.configure(parserConfig);
 		String testString = "<131>Apr 15 17:36:35 ROBXML3QRS [0x80800018][auth][error] rbm(RBM-Settings): "
 				+ "trans(3502888135)[request] gtid(3502888135): RBM: Resource access denied.";
 		Optional<MessageParserResult<JSONObject>> resultOptional = parser.parseOptionalResult(testString.getBytes(
@@ -136,10 +131,6 @@ public class GrokWebSphereParserTest {
 	
 	@Test
 	public void testParseOtherLine() throws Exception {
-		
-		//Set up parser, parse message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
-		parser.configure(parserConfig);
 		String testString = "<134>Apr 15 17:17:34 SAGPXMLQA333 [0x8240001c][audit][info] trans(191): (admin:default:system:*): "
 				+ "ntp-service 'NTP Service' - Operational state down";
 		Optional<MessageParserResult<JSONObject>> resultOptional = parser.parseOptionalResult(testString.getBytes(
@@ -163,10 +154,6 @@ public class GrokWebSphereParserTest {
 	
 	@Test
 	public void testParseMalformedLoginLine() throws Exception {
-		
-		//Set up parser, attempt to parse malformed message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
-		parser.configure(parserConfig);
 		String testString = "<133>Apr 15 17:47:28 ABCXML1413 [rojOut][0x81000033][auth][notice] rick007): "
 				+ "[120.43.200. User logged into 'cohlOut'.";
 		Optional<MessageParserResult<JSONObject>> resultOptional = parser.parseOptionalResult(testString.getBytes(
@@ -193,10 +180,6 @@ public class GrokWebSphereParserTest {
 	
 	@Test
 	public void testParseMalformedLogoutLine() throws Exception {
-		
-		//Set up parser, attempt to parse malformed message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
-		parser.configure(parserConfig);
 		String testString = "<134>Apr 15 18:02:27 PHIXML3RWD [0x81000019][auth][info] [14.122.2.201: "
 				+ "User 'hjpotter' logged out from 'default.";
 		Optional<MessageParserResult<JSONObject>> resultOptional = parser.parseOptionalResult(testString.getBytes(
@@ -222,10 +205,6 @@ public class GrokWebSphereParserTest {
 	
 	@Test
 	public void testParseMalformedRBMLine() throws Exception {
-		
-		//Set up parser, parse message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
-		parser.configure(parserConfig);
 		String testString = "<131>Apr 15 17:36:35 ROBXML3QRS [0x80800018][auth][error] rbmRBM-Settings): "
 				+ "trans3502888135)[request] gtid3502888135) RBM: Resource access denied.";
 		Optional<MessageParserResult<JSONObject>> resultOptional = parser.parseOptionalResult(testString.getBytes(
@@ -250,10 +229,6 @@ public class GrokWebSphereParserTest {
 	
 	@Test
 	public void testParseMalformedOtherLine() throws Exception {
-		
-		//Set up parser, parse message
-		GrokWebSphereParser parser = new GrokWebSphereParser();
-		parser.configure(parserConfig);
 		String testString = "<134>Apr 15 17:17:34 SAGPXMLQA333 [0x8240001c][audit][info] trans 191)  admindefaultsystem*): "
 				+ "ntp-service 'NTP Service' - Operational state down:";
 		Optional<MessageParserResult<JSONObject>> resultOptional = parser.parseOptionalResult(testString.getBytes(
@@ -275,5 +250,20 @@ public class GrokWebSphereParserTest {
 		assertEquals(null, parsedJSON.get("process"));
 		assertEquals("trans 191)  admindefaultsystem*): ntp-service 'NTP Service' - Operational state down:", parsedJSON.get("message"));
 	}
-	
+
+  @Test
+  public void getsReadCharsetFromConfig() {
+    Map<String, Object> config = new HashMap<>();
+    config.put(MessageParser.READ_CHARSET, StandardCharsets.UTF_16.toString());
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_16));
+  }
+
+  @Test
+  public void getsReadCharsetFromDefault() {
+    Map<String, Object> config = new HashMap<>();
+    parser.configure(config);
+    assertThat(parser.getReadCharset(), equalTo(StandardCharsets.UTF_8));
+  }
+
 }


### PR DESCRIPTION
I modified the `BasicParser` parent class to include the ability to configure a default read charset. I put the constant `READ_CHARSET` inside `MessageParser` because it's directly applicable as an option for any implementing parser that wants to add that option. There are a number of parsers that we support that don't extend `BasicParser`, so I handled them separately with the same type of code offered by the BasicParser. It's arguable that I could have come up with a parent class across all these types that enable configuring and reading the read charset value, but that seemed to blow this scope up a bit more because I think there's probably more to consider in design there. I opted for a modest level of duplication for now. I've added a new BasicParserTest that verifies the abstract class's new charset functionality. I compromised on the parser tests a bit - I verify the charset is getting set by the config, but I don't run a full integration test verifying the charset is read on the parse end. This might be not be acceptable, but some of these unit tests are gnarly. One outstanding question/issue might be around documenting the new config option - I didn't touch that.